### PR TITLE
Switch to Context Variables

### DIFF
--- a/src/pulsarity/ctx.py
+++ b/src/pulsarity/ctx.py
@@ -2,6 +2,8 @@
 Application context managment
 """
 
+from __future__ import annotations
+
 from asyncio import AbstractEventLoop
 from contextvars import ContextVar
 from typing import TYPE_CHECKING
@@ -10,10 +12,24 @@ from starlette.requests import Request
 from starlette.websockets import WebSocket
 
 if TYPE_CHECKING:
+    from pulsarity.events.broker import EventBroker
+    from pulsarity.interface.timer_manager import TimerInterfaceManager
+    from pulsarity.race.processor import RaceProcessorManager
+    from pulsarity.race.state import RaceStateManager
     from pulsarity.webserver.auth import PulsarityUser
 
+
 loop_ctx: ContextVar[AbstractEventLoop] = ContextVar("loop_ctx")
+
+
+event_broker_ctx: ContextVar[EventBroker] = ContextVar("event_broker_ctx")
+race_state_ctx: ContextVar[RaceStateManager] = ContextVar("race_state_ctx")
+race_processor_ctx: ContextVar[RaceProcessorManager] = ContextVar("race_processor_ctx")
+interface_manager_ctx: ContextVar[TimerInterfaceManager] = ContextVar(
+    "interface_manager_ctx"
+)
+
 request_ctx: ContextVar[Request] = ContextVar("request_ctx")
 websocket_ctx: ContextVar[WebSocket] = ContextVar("websocket_ctx")
-user_ctx: ContextVar["PulsarityUser"] = ContextVar("user_ctx")
+user_ctx: ContextVar[PulsarityUser] = ContextVar("user_ctx")
 user_permsissions_ctx: ContextVar[set[str]] = ContextVar("user_permsissions_ctx")

--- a/src/pulsarity/events/__init__.py
+++ b/src/pulsarity/events/__init__.py
@@ -2,7 +2,7 @@
 System events
 """
 
-from pulsarity.events.broker import EventBroker, event_broker, register_as_callback
+from pulsarity.events.broker import EventBroker, register_as_callback
 from pulsarity.events.enums import (
     EventSetupEvt,
     RaceSequenceEvt,
@@ -12,7 +12,6 @@ from pulsarity.events.enums import (
 
 __all__ = [
     "EventBroker",
-    "event_broker",
     "register_as_callback",
     "EventSetupEvt",
     "RaceSequenceEvt",

--- a/src/pulsarity/events/broker.py
+++ b/src/pulsarity/events/broker.py
@@ -14,6 +14,7 @@ from collections.abc import AsyncGenerator, Callable
 from dataclasses import dataclass, field
 from typing import Any, Self
 
+from pulsarity import ctx
 from pulsarity.events.enums import EvtPriority, _ApplicationEvt
 from pulsarity.utils import background
 from pulsarity.utils.asyncio import ensure_async
@@ -219,12 +220,6 @@ class EventBroker:
             self._connections.remove(connection)
 
 
-event_broker = EventBroker()
-"""
-A module singleton instance of `EventBroker`
-"""
-
-
 def register_as_callback(
     event: _ApplicationEvt,
     *,
@@ -242,7 +237,7 @@ def register_as_callback(
 
     @functools.wraps
     def inner(func):
-        event_broker.register_event_callback(
+        ctx.event_broker_ctx.get().register_event_callback(
             func, event, priority=priority, default_kwargs=default_kwargs
         )
 

--- a/src/pulsarity/interface/__init__.py
+++ b/src/pulsarity/interface/__init__.py
@@ -4,12 +4,11 @@ Hardware Interfaces
 
 from pulsarity.interface.timer_interface import Action, TimerData, TimerSetting
 
-from .timer_manager import TimerMode, interface_manager
+from .timer_manager import TimerMode
 
 __all__ = [
     "Action",
     "TimerSetting",
     "TimerData",
     "TimerMode",
-    "interface_manager",
 ]

--- a/src/pulsarity/interface/timer_manager.py
+++ b/src/pulsarity/interface/timer_manager.py
@@ -9,6 +9,7 @@ from collections.abc import AsyncGenerator
 from dataclasses import dataclass, field
 from enum import IntEnum, auto
 
+from pulsarity import ctx
 from pulsarity.interface.timer_interface import TimerData, TimerInterface
 from pulsarity.utils import background
 
@@ -69,7 +70,7 @@ class _DataManager:
     connections: set[asyncio.Queue[ExtendedTimerData]] = field(default_factory=set)
 
 
-class _TimerInterfaceManager:
+class TimerInterfaceManager:
     """
     Manages the abstract and active timer interfaces
     """
@@ -259,9 +260,6 @@ class _TimerInterfaceManager:
             self._tasks = None
 
 
-interface_manager = _TimerInterfaceManager()
-
-
 def register_interface(interface_class: type[TimerInterface]) -> type[TimerInterface]:
     """
     Decorator used for registering TimerInterface classes
@@ -269,5 +267,5 @@ def register_interface(interface_class: type[TimerInterface]) -> type[TimerInter
     :param interface_class: The timer interface class to register
     :return: The registered timer interface
     """
-    interface_manager.register(interface_class)
+    ctx.interface_manager_ctx.get().register(interface_class)
     return interface_class

--- a/src/pulsarity/race/__init__.py
+++ b/src/pulsarity/race/__init__.py
@@ -1,7 +1,3 @@
 """
 Race and results management
 """
-
-from pulsarity.race.state import race_state_manager
-
-__all__ = ["race_state_manager"]

--- a/src/pulsarity/race/state.py
+++ b/src/pulsarity/race/state.py
@@ -8,7 +8,7 @@ from random import random
 
 from pulsarity import ctx
 from pulsarity.database.raceformat import RaceFormat
-from pulsarity.events import RaceSequenceEvt, event_broker
+from pulsarity.events import RaceSequenceEvt
 from pulsarity.race.enums import RaceStatus
 
 logger = logging.getLogger(__name__)
@@ -163,6 +163,7 @@ class RaceStateManager:
         """
         Stop the race
         """
+        event_broker = ctx.event_broker_ctx.get()
 
         if self._program_handle is not None:
             self._program_handle.cancel()
@@ -208,6 +209,8 @@ class RaceStateManager:
         """
         Pause the race
         """
+        event_broker = ctx.event_broker_ctx.get()
+
         if self.status in RaceStatus.UNDERWAY:
             data: dict = {}
             event_broker.trigger_background(RaceSequenceEvt.RACE_PAUSE, data)
@@ -222,6 +225,8 @@ class RaceStateManager:
         """
         Resme the race
         """
+        event_broker = ctx.event_broker_ctx.get()
+
         if self.status != RaceStatus.PAUSED:
             return
 
@@ -264,6 +269,8 @@ class RaceStateManager:
         :param start_time: The time to start to schedule race start
         :param schedule: The format's race schedule
         """
+        event_broker = ctx.event_broker_ctx.get()
+
         data: dict = {}
         event_broker.trigger_background(RaceSequenceEvt.RACE_STAGE, data)
         self._set_status(RaceStatus.STAGING)
@@ -278,6 +285,8 @@ class RaceStateManager:
 
         :param schedule: The format's race schedule
         """
+        event_broker = ctx.event_broker_ctx.get()
+
         assert self._format is not None, "Can not start race with an unset schedule"
 
         data: dict = {}
@@ -300,6 +309,7 @@ class RaceStateManager:
 
         :param schedule: The format's race schedule
         """
+        event_broker = ctx.event_broker_ctx.get()
         assert self._format is not None, "Can not finish race with an unset schedule"
 
         data: dict = {}
@@ -323,6 +333,8 @@ class RaceStateManager:
         """
         Put the system into race stop mode
         """
+        event_broker = ctx.event_broker_ctx.get()
+
         data: dict = {}
         event_broker.trigger_background(RaceSequenceEvt.RACE_STOP, data)
         self._set_status(RaceStatus.STOPPED)
@@ -339,6 +351,3 @@ class RaceStateManager:
             self._race_record.clear()
             self._status = RaceStatus.READY
             logger.info("Race manager reset")
-
-
-race_state_manager = RaceStateManager()

--- a/src/pulsarity/webserver/websockets.py
+++ b/src/pulsarity/webserver/websockets.py
@@ -18,8 +18,7 @@ from starlette.websockets import WebSocket, WebSocketDisconnect
 from pulsarity import ctx
 from pulsarity.database import RaceFormat
 from pulsarity.database.permission import SystemDefaultPerms, UserPermission
-from pulsarity.events import RaceSequenceEvt, SpecialEvt, _ApplicationEvt, event_broker
-from pulsarity.race import race_state_manager
+from pulsarity.events import RaceSequenceEvt, SpecialEvt, _ApplicationEvt
 from pulsarity.utils import background
 from pulsarity.utils.asyncio import ensure_async
 
@@ -100,6 +99,7 @@ async def _write_data() -> None:
     """
     Handles writing event data over the websocket
     """
+    event_broker = ctx.event_broker_ctx.get()
     websocket = ctx.websocket_ctx.get()
     user = ctx.user_ctx.get()
     permissions = ctx.user_permsissions_ctx.get()
@@ -151,6 +151,7 @@ async def heatbeat_echo(ws_data: WSEventData):
 
     :param ws_data: Recieved websocket event data
     """
+    event_broker = ctx.event_broker_ctx.get()
     event_broker.publish(SpecialEvt.HEARTBEAT, ws_data.data, uuid_=ws_data.id)
 
 
@@ -179,7 +180,7 @@ async def schedule_race(ws_data: WSEventData):
     :param ws_data: Recieved websocket event data
     """
     format_ = RaceFormat()
-    race_state_manager.schedule_race(format_, **ws_data.data)
+    ctx.race_state_ctx.get().schedule_race(format_, **ws_data.data)
 
 
 @ws_event(RaceSequenceEvt.RACE_STOP)
@@ -189,7 +190,7 @@ async def race_stop():
 
     :param _ws_data: Recieved websocket event data
     """
-    race_state_manager.stop_race()
+    ctx.race_state_ctx.get().stop_race()
 
 
 routes = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,10 @@ from pulsarity.database import (
     Slot,
     setup_default_objects,
 )
+from pulsarity.events.broker import EventBroker
+from pulsarity.interface.timer_manager import TimerInterfaceManager
+from pulsarity.race.processor import RaceProcessorManager
+from pulsarity.race.state import RaceStateManager
 from pulsarity.utils import background
 from pulsarity.utils.config import get_configs_defaults
 from pulsarity.webserver import generate_application
@@ -23,8 +27,11 @@ from pulsarity.webserver import generate_application
 
 @pytest_asyncio.fixture(autouse=True)
 async def context_and_cleanup():
-    loop = asyncio.get_running_loop()
-    ctx.loop_ctx.set(loop)
+    ctx.loop_ctx.set(asyncio.get_running_loop())
+    ctx.event_broker_ctx.set(EventBroker())
+    ctx.race_state_ctx.set(RaceStateManager())
+    ctx.race_processor_ctx.set(RaceProcessorManager())
+    ctx.interface_manager_ctx.set(TimerInterfaceManager())
 
     yield
 

--- a/tests/test_general/test_timer_interface.py
+++ b/tests/test_general/test_timer_interface.py
@@ -5,12 +5,12 @@ import uuid
 import pytest
 
 from pulsarity.interface import TimerData, TimerMode
-from pulsarity.interface.timer_manager import _TimerInterfaceManager
+from pulsarity.interface.timer_manager import TimerInterfaceManager
 
 
 @pytest.fixture(name="interface_manager")
 def _interface_manager():
-    yield _TimerInterfaceManager()
+    yield TimerInterfaceManager()
 
 
 class BadTimerInterface: ...
@@ -63,7 +63,7 @@ class TestTimerInterface:
             self.rssi_queue.put_nowait(data)
 
 
-def test_register_interface_error(interface_manager: _TimerInterfaceManager):
+def test_register_interface_error(interface_manager: TimerInterfaceManager):
     """
     Test for registration of a bad interface
     """
@@ -72,7 +72,7 @@ def test_register_interface_error(interface_manager: _TimerInterfaceManager):
         interface_manager.register(BadTimerInterface)
 
 
-def test_register_interface_duplicate_error(interface_manager: _TimerInterfaceManager):
+def test_register_interface_duplicate_error(interface_manager: TimerInterfaceManager):
     """
     Test for the registration of duplicate interfaces
     """
@@ -82,7 +82,7 @@ def test_register_interface_duplicate_error(interface_manager: _TimerInterfaceMa
         interface_manager.register(TestTimerInterface)
 
 
-def test_unregister_interface(interface_manager: _TimerInterfaceManager):
+def test_unregister_interface(interface_manager: TimerInterfaceManager):
     """
     Test unregistering an interface
     """
@@ -90,7 +90,7 @@ def test_unregister_interface(interface_manager: _TimerInterfaceManager):
     interface_manager.unregister(TestTimerInterface.identifier)
 
 
-def test_unregister_interface_error(interface_manager: _TimerInterfaceManager):
+def test_unregister_interface_error(interface_manager: TimerInterfaceManager):
     """
     Test unregister an interface that wasn't registered
     """
@@ -99,7 +99,7 @@ def test_unregister_interface_error(interface_manager: _TimerInterfaceManager):
         interface_manager.unregister(TestTimerInterface.identifier)
 
 
-def test_already_instantiated_interface(interface_manager: _TimerInterfaceManager):
+def test_already_instantiated_interface(interface_manager: TimerInterfaceManager):
     """
     Test multiple instantiation of interface with the same data
     """
@@ -115,7 +115,7 @@ def test_already_instantiated_interface(interface_manager: _TimerInterfaceManage
         )
 
 
-def test_instantiate_interface_error(interface_manager: _TimerInterfaceManager):
+def test_instantiate_interface_error(interface_manager: TimerInterfaceManager):
     """
     Tests instantiating an interface that wasn't previously registered
     """
@@ -126,7 +126,7 @@ def test_instantiate_interface_error(interface_manager: _TimerInterfaceManager):
 
 
 @pytest.mark.asyncio
-async def test_manager_lifespan(interface_manager: _TimerInterfaceManager):
+async def test_manager_lifespan(interface_manager: TimerInterfaceManager):
     """
     Tests the lifespan of the interface manager
     """
@@ -135,14 +135,14 @@ async def test_manager_lifespan(interface_manager: _TimerInterfaceManager):
 
 
 @pytest.mark.asyncio
-async def test_manager_register_decorator(interface_manager: _TimerInterfaceManager):
+async def test_manager_register_decorator(interface_manager: TimerInterfaceManager):
     """
     Tests the usage of the `interface_manager.register` method
     as a decorator
     """
     # pylint: disable=C0115,W0612,W0212
 
-    interface_manager = _TimerInterfaceManager()
+    interface_manager = TimerInterfaceManager()
 
     num_interfaces = len(interface_manager._interfaces)
     assert num_interfaces == 0


### PR DESCRIPTION
Remove the use of module variables to manage singleton instances of classes, and switch to context variables for managing instances of the former singletons.